### PR TITLE
Set maxlength on name and email fields for product reviews.

### DIFF
--- a/Store/pages/product-reviews.xml
+++ b/Store/pages/product-reviews.xml
@@ -26,6 +26,7 @@
 						<property name="title" translatable="yes">Name</property>
 						<widget class="SwatEntry" id="product_review_fullname">
 							<property name="required" type="boolean">true</property>
+							<property name="maxlength" type="integer">50</property>
 						</widget>
 					</widget>
 					<widget class="SwatFormField">
@@ -33,6 +34,7 @@
 						<property name="note">Email addresses are not displayed with your comment and will not be shared.</property>
 						<widget class="SwatEmailEntry" id="product_review_email">
 							<property name="required" type="boolean">true</property>
+							<property name="maxlength" type="integer">50</property>
 						</widget>
 					</widget>
 				</widget>


### PR DESCRIPTION
This prevents DB error when spambots hit the page and fill the name and email fields with junk. I.e.:

```
MDB2 Error: invalid
_doQuery: [Error message: Could not execute statement]
... snip ...
[Native message: ERROR: value too long for type character varying(255)]
```
