### PR TITLE
Add support for easily adding additional search fields to the bottom of the search ui.

### DIFF
--- a/Store/admin/components/Order/Index.php
+++ b/Store/admin/components/Order/Index.php
@@ -12,7 +12,7 @@ require_once 'SwatDB/SwatDBClassMap.php';
  * Index page for Orders
  *
  * @package   Store
- * @copyright 2006-2012 silverorange
+ * @copyright 2006-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class StoreOrderIndex extends AdminSearch
@@ -25,6 +25,10 @@ class StoreOrderIndex extends AdminSearch
 		parent::initInternal();
 
 		$this->ui->loadFromXML($this->getSearchXml());
+		$this->addAdditionalSearchFields(
+			$this->getAdditionalSearchFieldsUiXmlFiles()
+		);
+
 		$this->ui->loadFromXML($this->getUiXml());
 
 		if ($this->ui->hasWidget('search_region')) {
@@ -76,6 +80,29 @@ class StoreOrderIndex extends AdminSearch
 	protected function getUiXml()
 	{
 		return 'Store/admin/components/Order/index.xml';
+	}
+
+	// }}}
+	// {{{ protected function addAdditionalSearchFields()
+
+	protected function addAdditionalSearchFields(array $ui_xml_files)
+	{
+		if ($this->ui->hasWidget('additional_search_fields')) {
+			foreach ($ui_xml_files as $ui_xml) {
+				$this->ui->loadFromXML(
+					$ui_xml,
+					$this->ui->getWidget('additional_search_fields')
+				);
+			}
+		}
+	}
+
+	// }}}
+	// {{{ protected function getAdditionalSearchFieldsUiXmlFiles()
+
+	protected function getAdditionalSearchFieldsUiXmlFiles()
+	{
+		return array();
 	}
 
 	// }}}

--- a/Store/admin/components/Order/search.xml
+++ b/Store/admin/components/Order/search.xml
@@ -70,6 +70,7 @@
 					<widget class="SwatCheckbox" id="search_comments" />
 				</widget>
 			</widget>
+			<widget class="SwatContainer" id="additional_search_fields" />
 			<widget class="SwatFooterFormField">
 				<widget class="SwatButton" id="submit_button">
 					<property name="title" translatable="yes">Search</property>


### PR DESCRIPTION
This could be ported to other commonly subclassed search indexes if it becomes widely useful.
