### PR TITLE
Don't require the final note widget on checkout final pages.

### DIFF
--- a/Store/pages/StoreCheckoutFinalPage.php
+++ b/Store/pages/StoreCheckoutFinalPage.php
@@ -6,7 +6,7 @@ require_once 'Store/pages/StoreCheckoutPage.php';
  * Abstract base class for final page of the checkout
  *
  * @package   Store
- * @copyright 2006-2013 silverorange
+ * @copyright 2006-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class StoreCheckoutFinalPage extends StoreCheckoutPage
@@ -167,12 +167,14 @@ abstract class StoreCheckoutFinalPage extends StoreCheckoutPage
 
 	protected function buildFinalNote(StoreOrder $order)
 	{
-		$note = $this->ui->getWidget('final_note');
-		if ($note instanceof SwatContentBlock) {
-			$note->content_type = 'text/xml';
-			ob_start();
-			$this->displayFinalNote($order);
-			$note->content = ob_get_clean();
+		if ($this->ui->hasWidget('final_note')) {
+			$note = $this->ui->getWidget('final_note');
+			if ($note instanceof SwatContentBlock) {
+				$note->content_type = 'text/xml';
+				ob_start();
+				$this->displayFinalNote($order);
+				$note->content = ob_get_clean();
+			}
 		}
 	}
 


### PR DESCRIPTION
Check to see if the widget exists before building content for it.
