### PR TITLE
rename 'Address' to 'Street Address'

### DIFF
--- a/Store/pages/account-address-edit.xml
+++ b/Store/pages/account-address-edit.xml
@@ -26,7 +26,7 @@
 			</widget>
 		</widget>
 		<widget class="SwatFormField" id="address_line1_field">
-			<property name="title" translatable="yes">Address</property>
+			<property name="title" translatable="yes">Street Address</property>
 			<widget class="SwatTextarea" id="line1">
 				<property name="required" type="boolean">true</property>
 				<property name="resizeable" type="boolean">false</property>

--- a/Store/pages/checkout-billing-address.xml
+++ b/Store/pages/checkout-billing-address.xml
@@ -31,7 +31,7 @@
 			</widget>
 		</widget>
 		<widget class="SwatFormField" id="billing_address_line1_field">
-			<property name="title" translatable="yes">Address</property>
+			<property name="title" translatable="yes">Street Address</property>
 			<widget class="SwatTextarea" id="billing_address_line1">
 				<property name="required" type="boolean">true</property>
 				<property name="resizeable" type="boolean">false</property>

--- a/Store/pages/checkout-shipping-address.xml
+++ b/Store/pages/checkout-shipping-address.xml
@@ -34,7 +34,7 @@
 			</widget>
 		</widget>
 		<widget class="SwatFormField" id="shipping_address_line1_field">
-			<property name="title" translatable="yes">Address</property>
+			<property name="title" translatable="yes">Street Address</property>
 			<widget class="SwatTextarea" id="shipping_address_line1">
 				<property name="required" type="boolean">true</property>
 				<property name="resizeable" type="boolean">false</property>


### PR DESCRIPTION
keeps people from accidentally entering their full address into the textarea - which has been a small problem
