### PR TITLE
Default the country flydown on account address edits.

### DIFF
--- a/Store/pages/StoreAccountAddressEditPage.php
+++ b/Store/pages/StoreAccountAddressEditPage.php
@@ -139,6 +139,9 @@ class StoreAccountAddressEditPage extends SiteDBEditPage
 			$country_flydown->addOption($country->id, $country->title);
 		}
 
+		// default country flydown to the country of the current locale
+		$country_flydown->value = $this->app->getCountry();
+
 		$data = array();
 		foreach ($countries as $country) {
 


### PR DESCRIPTION
This matches the behaviour of the checkout, and prevents the provstate flydwon showing at the same time as the other_provstate field.
