### PR TITLE
Only display card details if the flags are true, and the matching values exist.

### DIFF
--- a/Store/dataobjects/StorePaymentMethod.php
+++ b/Store/dataobjects/StorePaymentMethod.php
@@ -532,18 +532,16 @@ abstract class StorePaymentMethod extends SwatDBDataObject
 				$this->displayCard($passphrase);
 			}
 
-			if ($display_details) {
-				if (
-					(
-						$this->card_expiry instanceof SwatDate &&
-						$this->display_parts['card_expiry']
-					) || (
-						$this->card_fullname != '' &&
-						$this->display_parts['card_fullname']
-					)
-				) {
-					$this->displayCardDetails();
-				}
+			if ($display_details &&
+				(
+					$this->card_expiry instanceof SwatDate &&
+					$this->display_parts['card_expiry']
+				) || (
+					$this->card_fullname != '' &&
+					$this->display_parts['card_fullname']
+				)
+			) {
+				$this->displayCardDetails();
 			}
 		} elseif ($this->payment_type->isPayPal()) {
 			echo SwatString::minimizeEntities($this->payment_type->title);


### PR DESCRIPTION
The old code would display an empty span if the flags and data didn't line up. For example if the expiry date existed on the payment method, but the flag said not to display it, the span would still get built. This prevents that.

Also do some code cleanup of related lines.
