### PR TITLE
Make various class properties protected not private.

### DIFF
--- a/Store/admin/components/Account/AddressDelete.php
+++ b/Store/admin/components/Account/AddressDelete.php
@@ -14,10 +14,10 @@ require_once 'SwatI18N/SwatI18NLocale.php';
  */
 class StoreAccountAddressDelete extends AdminDBDelete
 {
-	// {{{ private properties
+	// {{{ protected properties
 
-	private $account;
-	private $account_id;
+	protected $account;
+	protected $account_id;
 
 	// }}}
 

--- a/Store/admin/components/Account/AddressEdit.php
+++ b/Store/admin/components/Account/AddressEdit.php
@@ -28,13 +28,10 @@ class StoreAccountAddressEdit extends AdminDBEdit
 	 */
 	protected $country;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * @var StoreAccount
 	 */
-	private $account;
+	protected $account;
 
 	// }}}
 


### PR DESCRIPTION
So subclasses can use them...

Our older code has a fetish for private properties I don't remember the logic for.
