### PR TITLE
Only attempt to set the fullname visibility if the fullname field exists on the view.

### DIFF
--- a/Store/pages/StoreCheckoutConfirmationPage.php
+++ b/Store/pages/StoreCheckoutConfirmationPage.php
@@ -1346,8 +1346,15 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 
 		$view->data = $ds;
 
-		if (!isset($ds->fullname) || $ds->fullname == '')
+		if (
+			$view->hasField('fullname_field') &&
+			(
+				!isset($ds->fullname) ||
+				$ds->fullname == ''
+			)
+		) {
 			$view->getField('fullname_field')->visible = false;
+		}
 	}
 
 	// }}}


### PR DESCRIPTION
This fixes a SwatWidgetNotFoundException on sites that never include a fullname field.
