### PR TITLE
Make link optional for getCheckoutEditLink().

### DIFF
--- a/Store/pages/StoreCheckoutConfirmationPage.php
+++ b/Store/pages/StoreCheckoutConfirmationPage.php
@@ -1268,9 +1268,15 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 	// }}}
 	// {{{ protected function getCheckoutEditLink()
 
-	protected function getCheckoutEditLink($link)
+	protected function getCheckoutEditLink($link = '')
 	{
-		return $this->getEditLink($this->getCheckoutSource().'/'.$link);
+		if ($link == '') {
+			$link = $this->getCheckoutSource();
+		} else {
+			$link = $this->getCheckoutSource().'/'.$link;
+		}
+
+		return $this->getEditLink($link);
 	}
 
 	// }}}


### PR DESCRIPTION
If not specified, it now goes to getCheckoutSource().
