### PR TITLE
Don't look up available item from null sku

### DIFF
--- a/Store/dataobjects/StoreOrderItem.php
+++ b/Store/dataobjects/StoreOrderItem.php
@@ -295,7 +295,7 @@ class StoreOrderItem extends SwatDBDataObject
 			$item = SwatDB::query($this->db, $sql, $wrapper)->getFirst();
 
 			// if lookup by id failed, try lookup by sku
-			if (!($item instanceof StoreItem)) {
+			if (!$item instanceof StoreItem && $this->sku != '') {
 				$sql = sprintf(
 					'select Item.* from Item
 					inner join AvailableItemView


### PR DESCRIPTION
This is a bug where we try to look up an available item when sku is null, and end up just grabbing the first item with no sku.

See story: https://www.pivotaltracker.com/story/show/82560936
