### PR TITLE
Add support for custom invoice numbers and order descriptions to the Authorize.net payment provider.

### DIFF
--- a/Store/StoreAuthorizeNetPaymentProvider.php
+++ b/Store/StoreAuthorizeNetPaymentProvider.php
@@ -37,7 +37,7 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 	protected $mode;
 
 	protected $invoice_number_prefix;
-	protected $order_description_prefix = Store::_('Order');
+	protected $order_description_prefix;
 
 	// }}}
 	// {{{ public function __construct()
@@ -102,10 +102,10 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 			$this->invoice_number_prefix = $parameters['invoice_number_prefix'];
 		}
 
-		if (isset($parameters['order_description_prefix'])) {
-			$this->order_description_prefix =
-				$parameters['order_description_prefix'];
-		}
+		$this->order_description_prefix =
+			(isset($parameters['order_description_prefix']))
+			? $parameters['order_description_prefix']
+			: Store::_('Order');
 	}
 
 	// }}}

--- a/Store/StoreAuthorizeNetPaymentProvider.php
+++ b/Store/StoreAuthorizeNetPaymentProvider.php
@@ -36,7 +36,16 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 	 */
 	protected $mode;
 
+	/**
+	 * @var string
+	 * @see AuthorizeNetPaymentProvider::__construct()
+	 */
 	protected $invoice_number_prefix;
+
+	/**
+	 * @var string
+	 * @see AuthorizeNetPaymentProvider::__construct()
+	 */
 	protected $order_description_prefix;
 
 	// }}}

--- a/Store/StoreAuthorizeNetPaymentProvider.php
+++ b/Store/StoreAuthorizeNetPaymentProvider.php
@@ -49,7 +49,7 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 	 *
 	 * <kbd>mode</kbd>                     - optional. Transaction mode to use.
 	 *                                       Must be one of either 'live' or
-     *                                       'sandbox'. If not specified,
+	 *                                       'sandbox'. If not specified,
 	 *                                       'sandbox' is used.
 	 * <kbd>login_id</kbd>                 - required. Login identifier for
 	 *                                       Authorize.net authentication.
@@ -294,7 +294,7 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 		// from 19 to account for the space added.
 		$invoice_number_prefix = $this->truncateField(
 			$this->invoice_number_prefix,
-			19-strlen($order->id)
+			19 - strlen($order->id)
 		);
 
 		return ($invoice_number_prefix = '')

--- a/Store/StoreAuthorizeNetPaymentProvider.php
+++ b/Store/StoreAuthorizeNetPaymentProvider.php
@@ -37,7 +37,7 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 	protected $mode;
 
 	protected $invoice_number_prefix;
-	protected $order_description_prefix = Store::_('Order ');
+	protected $order_description_prefix = Store::_('Order');
 
 	// }}}
 	// {{{ public function __construct()
@@ -290,13 +290,16 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 
 	protected function getInvoiceNumber(StoreOrder $order)
 	{
-		// Authorize.net only allows 20 chars for invoice number.
+		// Authorize.net only allows 20 chars for invoice number. Get max length
+		// from 19 to account for the space added.
 		$invoice_number_prefix = $this->truncateField(
 			$this->invoice_number_prefix,
-			20-strlen($order->id)
+			19-strlen($order->id)
 		);
 
-		return $invoice_number_prefix.$order->id;
+		return ($invoice_number_prefix = '')
+			? $order->id
+			: $invoice_number_prefix.' '.$order->id;
 	}
 
 	// }}}
@@ -304,7 +307,7 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 
 	protected function getOrderDescription(StoreOrder $order)
 	{
-		return $this->order_description_prefix.$order->id;
+		return $this->order_description_prefix.' '.$order->id;
 	}
 
 	// }}}

--- a/Store/StoreAuthorizeNetPaymentProvider.php
+++ b/Store/StoreAuthorizeNetPaymentProvider.php
@@ -306,7 +306,7 @@ class StoreAuthorizeNetPaymentProvider extends StorePaymentProvider
 			19 - strlen($order->id)
 		);
 
-		return ($invoice_number_prefix = '')
+		return ($invoice_number_prefix == '')
 			? $order->id
 			: $invoice_number_prefix.' '.$order->id;
 	}


### PR DESCRIPTION
We customize the invoice number and order description on many sites, and this allows us to do with less custom local code across each site.

It also protects us from going over the 20 character limit on invoice number.