### PR TITLE
Better braintree error reporting

### DIFF
--- a/Store/StoreBraintreePaymentProvider.php
+++ b/Store/StoreBraintreePaymentProvider.php
@@ -485,7 +485,7 @@ class StoreBraintreePaymentProvider extends StorePaymentProvider
 			return $e;
 		}
 
-		return new StorePaymentBraintreeException($response->message);
+		return new StorePaymentBraintreeException(print_r($response, true));
 	}
 
 	// }}}

--- a/Store/StoreBraintreePaymentProvider.php
+++ b/Store/StoreBraintreePaymentProvider.php
@@ -154,7 +154,7 @@ class StoreBraintreePaymentProvider extends StorePaymentProvider
 		// check for errors and throw exception
 		if (!$response->success) {
 			throw new StorePaymentBraintreeException(
-				'Error processing Braintree payment.',
+				'Error processing Braintree payment: ' . $response->message,
 				0,
 				$response
 			);

--- a/Store/StoreBraintreePaymentProvider.php
+++ b/Store/StoreBraintreePaymentProvider.php
@@ -485,7 +485,7 @@ class StoreBraintreePaymentProvider extends StorePaymentProvider
 			return $e;
 		}
 
-		return new StorePaymentBraintreeException(print_r($response, true));
+		return new StorePaymentBraintreeException($response->message);
 	}
 
 	// }}}

--- a/Store/exceptions/StorePaymentBraintreeException.php
+++ b/Store/exceptions/StorePaymentBraintreeException.php
@@ -7,3 +7,5 @@
 class StorePaymentBraintreeException extends StorePaymentException
 {
 }
+
+?>

--- a/Store/exceptions/StorePaymentBraintreeException.php
+++ b/Store/exceptions/StorePaymentBraintreeException.php
@@ -2,43 +2,8 @@
 
 /**
  * @package   Store
- * @copyright 2015-2016 silverorange
+ * @copyright 2015-2018 silverorange
  */
 class StorePaymentBraintreeException extends StorePaymentException
 {
-	// {{{ protected properties
-
-	/**
-	 * @param Braintree\Base
-	 */
-	protected $response = null;
-
-	// }}}
-	// {{{ public function __construct()
-
-	/**
-	 * @param string $message
-	 * @param integer $code
-	 * @param Braintree\Base $response
-	 */
-	public function __construct($message, $code, Braintree\Base $response)
-	{
-		parent::__construct($message, $code);
-		$this->response = $response;
-	}
-
-	// }}}
-	// {{{ public function getResponse()
-
-	/**
-	 * @return Braintree\Base
-	 */
-	public function getResponse()
-	{
-		return $this->response;
-	}
-
-	// }}}
 }
-
-?>

--- a/Store/exceptions/StorePaymentBraintreeGatewayException.php
+++ b/Store/exceptions/StorePaymentBraintreeGatewayException.php
@@ -28,3 +28,5 @@ class StorePaymentBraintreeGatewayException extends StorePaymentException
 
 	// }}}
 }
+
+?>

--- a/Store/exceptions/StorePaymentBraintreeGatewayException.php
+++ b/Store/exceptions/StorePaymentBraintreeGatewayException.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @package   Store
+ * @copyright 2018 silverorange
+ */
+class StorePaymentBraintreeGatewayException extends StorePaymentException
+{
+}

--- a/Store/exceptions/StorePaymentBraintreeGatewayException.php
+++ b/Store/exceptions/StorePaymentBraintreeGatewayException.php
@@ -6,4 +6,25 @@
  */
 class StorePaymentBraintreeGatewayException extends StorePaymentException
 {
+	// {{{ protected properties
+
+	protected $reason;
+
+	// }}}
+	// {{{ public function setReason()
+
+	public function setReason($reason)
+	{
+		$this->reason = $reason;
+	}
+
+	// }}}
+	// {{{ public function getReason()
+
+	public function getReason()
+	{
+		return $this->reason;
+	}
+
+	// }}}
 }

--- a/Store/exceptions/StorePaymentBraintreeGatewayException.php
+++ b/Store/exceptions/StorePaymentBraintreeGatewayException.php
@@ -4,7 +4,7 @@
  * @package   Store
  * @copyright 2018 silverorange
  */
-class StorePaymentBraintreeGatewayException extends StorePaymentException
+class StorePaymentBraintreeGatewayException extends StorePaymentBraintreeException
 {
 	// {{{ protected properties
 

--- a/Store/exceptions/StorePaymentBraintreeProcessorException.php
+++ b/Store/exceptions/StorePaymentBraintreeProcessorException.php
@@ -7,3 +7,5 @@
 class StorePaymentBraintreeProcessorException extends StorePaymentException
 {
 }
+
+?>

--- a/Store/exceptions/StorePaymentBraintreeProcessorException.php
+++ b/Store/exceptions/StorePaymentBraintreeProcessorException.php
@@ -4,7 +4,7 @@
  * @package   Store
  * @copyright 2018 silverorange
  */
-class StorePaymentBraintreeProcessorException extends StorePaymentException
+class StorePaymentBraintreeProcessorException extends StorePaymentBraintreeException
 {
 }
 

--- a/Store/exceptions/StorePaymentBraintreeProcessorException.php
+++ b/Store/exceptions/StorePaymentBraintreeProcessorException.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @package   Store
+ * @copyright 2018 silverorange
+ */
+class StorePaymentBraintreeProcessorException extends StorePaymentException
+{
+}

--- a/Store/exceptions/StorePaymentBraintreeSettlementException.php
+++ b/Store/exceptions/StorePaymentBraintreeSettlementException.php
@@ -4,7 +4,7 @@
  * @package   Store
  * @copyright 2018 silverorange
  */
-class StorePaymentBraintreeSettlementException extends StorePaymentException
+class StorePaymentBraintreeSettlementException extends StorePaymentBraintreeException
 {
 }
 

--- a/Store/exceptions/StorePaymentBraintreeSettlementException.php
+++ b/Store/exceptions/StorePaymentBraintreeSettlementException.php
@@ -7,3 +7,5 @@
 class StorePaymentBraintreeSettlementException extends StorePaymentException
 {
 }
+
+?>

--- a/Store/exceptions/StorePaymentBraintreeSettlementException.php
+++ b/Store/exceptions/StorePaymentBraintreeSettlementException.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @package   Store
+ * @copyright 2018 silverorange
+ */
+class StorePaymentBraintreeSettlementException extends StorePaymentException
+{
+}

--- a/Store/exceptions/StorePaymentBraintreeValidationException.php
+++ b/Store/exceptions/StorePaymentBraintreeValidationException.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @package   Store
+ * @copyright 2018 silverorange
+ */
+class StorePaymentBraintreeValidationException extends StorePaymentException
+{
+}

--- a/Store/exceptions/StorePaymentBraintreeValidationException.php
+++ b/Store/exceptions/StorePaymentBraintreeValidationException.php
@@ -7,3 +7,5 @@
 class StorePaymentBraintreeValidationException extends StorePaymentException
 {
 }
+
+?>

--- a/Store/exceptions/StorePaymentBraintreeValidationException.php
+++ b/Store/exceptions/StorePaymentBraintreeValidationException.php
@@ -4,7 +4,7 @@
  * @package   Store
  * @copyright 2018 silverorange
  */
-class StorePaymentBraintreeValidationException extends StorePaymentException
+class StorePaymentBraintreeValidationException extends StorePaymentBraintreeException
 {
 }
 


### PR DESCRIPTION
https://hippoeducation.tpondemand.com/entity/1784-add-better-reporting-for-storepaymentbraintreeexception

For testing I edited the `pay()` method in the `StoreBraintreePaymentProvider` to trigger errors using some of the techniques described here: https://developers.braintreepayments.com/reference/general/testing/php