### PR TITLE
Remove StoreMailChimpModule from default modules

### DIFF
--- a/Store/StoreApplication.php
+++ b/Store/StoreApplication.php
@@ -99,7 +99,6 @@ abstract class StoreApplication extends SiteWebApplication
 				'cookie' => SiteCookieModule::class,
 				'cart' => StoreCartModule::class,
 				'checkout' => StoreCheckoutModule::class,
-				'mailchimp' => StoreMailChimpModule::class,
 				'messages' => SiteMessagesModule::class,
 				'config' => SiteConfigModule::class,
 				'ads' => SiteAdModule::class,


### PR DESCRIPTION
This module no longer exists due to the MC3 upgrades.

This was removed in https://github.com/silverorange/store/pull/133/files . I think it wasn't noticed because most sites override the `getDefaultModuleList` method, but `surviving-infancy` uses the default version, so updating `surviving-infancy` to the newest version of `store` generates this error when loading any page:

```
Message:
Error: Class 'StoreMailChimpModule' not found in /so/sites/surviving-infancy/work-meg/vendor/silverorange/site/Site/SiteApplication.php:679
Stack trace:
#0 /so/sites/surviving-infancy/work-meg/vendor/silverorange/site/Site/SiteApplication.php(140): SiteApplication->addDefaultModules()
#1 /so/sites/surviving-infancy/work-meg/www/index.php(9): SiteApplication->__construct('surviving-infan...', '/so/sites/survi...')
#2 {main}
Code:
0
Created in file /so/sites/surviving-infancy/work-meg/vendor/silverorange/swat/Swat/exceptions/SwatException.php on line 460.

Stack Trace:
0.
In file unknown line unknown.
Method: SwatException::handle(<Error object>)
```