### PR TITLE
Adding final storeorderitem price and using it in analytics instead of the regular price

### DIFF
--- a/Store/StoreAnalyticsOrderTracker.php
+++ b/Store/StoreAnalyticsOrderTracker.php
@@ -261,7 +261,7 @@ class StoreAnalyticsOrderTracker
 			$this->getSku($item),
 			$this->getProductTitle($item),
 			$this->getCategoryTitle($item),
-			$item->price,
+			$item->getFinalPrice(),
 			$item->quantity
 		);
 	}

--- a/Store/dataobjects/StoreOrderItem.php
+++ b/Store/dataobjects/StoreOrderItem.php
@@ -404,6 +404,17 @@ class StoreOrderItem extends SwatDBDataObject
 	}
 
 	// }}}
+	// {{{ protected function getFinalPrice()
+
+	public function getFinalPrice()
+	{
+		$promotion_discount =
+			$this->promotion_discount ? $this->promotion_discount : 0.00;
+
+		return $this->price - $promotion_discount;
+	}
+
+	// }}}
 }
 
 ?>


### PR DESCRIPTION
https://airtable.com/tblHi2RES2ktb1XG9/viw4pG7kWWQs7XWjx/recnZCnGz7JOCmPbx?blocks=hide

This ended up being a fairly simple fix once I dug into how our order process works.

The `OrderItem` table stores the order item details for a transaction and the issue is that `price` isn't really the final price for an item because it doesn't include discounts and promotions. Luckily the discounts per item are already calculated and stored in `OrderItem`.

`promotion_discount` allow nulls so if it isn't set the code will default to `0.00`. The `discount` and `discount_extension` columns do not need to be subtracted from the price as the price per item is correct when they are used. The `quantity_discount` doesn't appear to be used (`0.00` is the only value in all the dbs) so that isn't subtracted as well.

It looks like group discounts are done via promotions so that should be covered by this fix as well.

To test:
- Checkout this PR in your `store` directory.
- Test the `hippo` and `essentials` sites by going into your directory for them and running  `gulp --symlinks=store`
- Add `google_account = "UA-104116768-1"` to the `analytics` section of the site's .ini file (or update the db as necessary)
- Check sales with single or multiple items with and without discounts and make sure the correct item price is being sent to GA. I mostly use the Chrome extension `GA Debug` and view the `console` tab in developer tools for testing and sometimes check the GA dashboard to make sure it's getting everything.

Some tests of note that I did were LLSA with multiple items and discounts as well as PPR with the assessments bundled in (this is where the `discount` and `discount_extension` columns are populated). The RAP sites will be fixed in a `kos` PR as they work differently.