### PR TITLE
Fix Checkout when there's a credit card validation error

### DIFF
--- a/Store/StoreBraintreePaymentProvider.php
+++ b/Store/StoreBraintreePaymentProvider.php
@@ -156,8 +156,6 @@ class StoreBraintreePaymentProvider extends StorePaymentProvider
 			throw $this->generateExceptionFromResponse($response);
 		}
 
-		throw new StorePaymentBraintreeProcessorException('Nick test', 2010);
-
 		return $this->createPaymentMethodTransaction($response->transaction);
 	}
 

--- a/Store/StoreBraintreePaymentProvider.php
+++ b/Store/StoreBraintreePaymentProvider.php
@@ -156,6 +156,8 @@ class StoreBraintreePaymentProvider extends StorePaymentProvider
 			throw $this->generateExceptionFromResponse($response);
 		}
 
+		throw new StorePaymentBraintreeValidationException('Nick test');
+
 		return $this->createPaymentMethodTransaction($response->transaction);
 	}
 

--- a/Store/StoreBraintreePaymentProvider.php
+++ b/Store/StoreBraintreePaymentProvider.php
@@ -156,7 +156,7 @@ class StoreBraintreePaymentProvider extends StorePaymentProvider
 			throw $this->generateExceptionFromResponse($response);
 		}
 
-		throw new StorePaymentBraintreeValidationException('Nick test');
+		throw new StorePaymentBraintreeProcessorException('Nick test', 2010);
 
 		return $this->createPaymentMethodTransaction($response->transaction);
 	}

--- a/Store/pages/StoreCheckoutConfirmationPage.php
+++ b/Store/pages/StoreCheckoutConfirmationPage.php
@@ -715,6 +715,9 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 
 		if ($this->shouldSaveAccount()) {
 			$duplicate_account = $this->app->session->account->duplicate();
+		}
+
+		if ($this->shouldSaveAccount()) {
 			try {
 				$this->saveAccount();
 			} catch (Exception $e) {
@@ -740,6 +743,11 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 			$this->processPayment();
 		} catch (Exception $e) {
 			$db_transaction->rollback();
+
+			if ($this->shouldSaveAccount()) {
+				$this->app->session->account = $duplicate_account;
+			}
+
 			$this->app->session->order = $duplicate_order;
 
 			if ($this->handleException($e)) {


### PR DESCRIPTION
## To test it broken:
 - add this line to `StoreBrainTreePaymentProvider` in master https://github.com/silverorange/store/pull/144/files#r609039693
 - Run `yarn start --symlinks=store`
 - Check out
 - You'll incorrectly see the "Welcome to EM:RAP" modal.
 - When you dismiss it, you'll be taken back to the checkout
 - Remove the test line in `StoreBrainTreePaymentProvider` and finish the checkout
 - You'll get an SQL error saving `AccountAddress`

To reset everything, you'll likely have to open the web inspector and delete all of the `emrap` cookies.

## To test it working:
 - check out this PR
 - Run `yarn start --symlinks=store`
 - Check out
 - You'll see a red warning telling you the credit card is incorrect
 - Remove the test line
 - Finish checkout