### PR TITLE
Convert use of moneyFormat to formatCurrency

### DIFF
--- a/Store/StoreOrderConfirmationMailMessage.php
+++ b/Store/StoreOrderConfirmationMailMessage.php
@@ -378,9 +378,11 @@ abstract class StoreOrderConfirmationMailMessage extends
 	{
 		$locale = $this->order->locale->id;
 
+		$formatter = SwatI18NLocale::get($locale);
+
 		printf('   Price: %s, Total: %s',
-			SwatString::moneyFormat($item->price, $locale),
-			SwatString::moneyFormat($item->extension, $locale));
+			$formatter->formatCurrency($item->price),
+			$formatter->formatCurrency($item->extension));
 	}
 
 	// }}}
@@ -391,9 +393,11 @@ abstract class StoreOrderConfirmationMailMessage extends
 		$order = $this->order;
 		$locale = $this->order->locale->id;
 
+		$formatter = SwatI18NLocale::get($locale);
+
 		$subtotal = $order->getSubtotal();
 		printf(Store::_('Subtotal: %s'),
-			SwatString::moneyFormat($subtotal, $locale));
+			$formatter->formatCurrency($subtotal));
 
 		echo self::LINE_BREAK;
 
@@ -402,28 +406,28 @@ abstract class StoreOrderConfirmationMailMessage extends
 				self::LINE_BREAK;
 		} else {
 			printf(Store::_('Shipping: %s'),
-				SwatString::moneyFormat($order->shipping_total, $locale));
+				$formatter->formatCurrency($order->shipping_total));
 
 			echo self::LINE_BREAK;
 		}
 
 		if ($order->surcharge_total > 0) {
 			printf(Store::_('Surcharge: %s'),
-				SwatString::moneyFormat($order->surcharge_total, $locale));
+				$formatter->formatCurrency($order->surcharge_total));
 
 			echo self::LINE_BREAK;
 		}
 
 		if ($order->tax_total > 0) {
 			printf(Store::_('Tax: %s'),
-				SwatString::moneyFormat($order->tax_total, $locale));
+				$formatter->formatCurrency($order->tax_total));
 
 			echo self::LINE_BREAK;
 		}
 
 		echo self::LINE_BREAK;
 		printf(Store::_('Total: %s'),
-			SwatString::moneyFormat($order->total, $locale));
+			$formatter->formatCurrency($order->total));
 	}
 
 	// }}}

--- a/Store/StoreYeOldePriceCellRenderer.php
+++ b/Store/StoreYeOldePriceCellRenderer.php
@@ -55,7 +55,9 @@ class StoreYeOldePriceCellRenderer extends StoreItemPriceCellRenderer
 		$formatter = SwatI18NLocale::get($locale);
 
 		$money = SwatString::minimizeEntities(
-			$formatter->formatCurrency($value, $display_currency, array('fractional_digits' => $decimal_places))
+			$formatter->formatCurrency(
+				$value, $display_currency, array('fractional_digits' => $decimal_places)
+			)
 		);
 
 		if ($locale !== null) {

--- a/Store/StoreYeOldePriceCellRenderer.php
+++ b/Store/StoreYeOldePriceCellRenderer.php
@@ -52,9 +52,11 @@ class StoreYeOldePriceCellRenderer extends StoreItemPriceCellRenderer
 		$display_currency = false,
 		$decimal_places = null
 	) {
+		$formatter = SwatI18NLocale::get($locale);
+
 		$money = SwatString::minimizeEntities(
-			SwatString::moneyFormat(
-				$value, $locale, $display_currency, $decimal_places));
+			$formatter->formatCurrency($value, $display_currency, array('fractional_digits' => $decimal_places))
+		);
 
 		if ($locale !== null) {
 			$old_locale = setlocale(LC_ALL, 0);

--- a/Store/StoreYeOldePriceCellRenderer.php
+++ b/Store/StoreYeOldePriceCellRenderer.php
@@ -54,10 +54,8 @@ class StoreYeOldePriceCellRenderer extends StoreItemPriceCellRenderer
 	) {
 		$formatter = SwatI18NLocale::get($locale);
 
-		$money = SwatString::minimizeEntities(
-			$formatter->formatCurrency(
-				$value, $display_currency, array('fractional_digits' => $decimal_places)
-			)
+		$money = $formatter->formatCurrency(
+			$value, false, array('fractional_digits' => $decimal_places)
 		);
 
 		if ($locale !== null) {
@@ -71,6 +69,10 @@ class StoreYeOldePriceCellRenderer extends StoreItemPriceCellRenderer
 
 		$lc = localeconv();
 		$decimal_point = $lc['mon_decimal_point'];
+
+		if ($display_currency) {
+			$money.= ' '.$lc['int_curr_symbol'];
+		}
 
 		// convert decimal character to UTF-8
 		$character_set = nl_langinfo(CODESET);


### PR DESCRIPTION
One breaking change in PHP 8 is the removal of the function `money_format`. Any code using the deprecated `SwatString::MoneyFormat` has to be changed to use `SwatI18NLocale::formatCurrency`.