### PR TITLE
Bump site version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 		"pear/validate_finance_creditcard": ">=0.5.2",
 		"silverorange/admin": "^5.4.0",
 		"silverorange/net_notifier": "^1.0.0",
-		"silverorange/site": "^10.1.0",
+		"silverorange/site": "^10.1.0 || ^11.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0",
 		"silverorange/xml_rpc_ajax": "^3.1.0",
 		"silverorange/yui": "^1.0.11"


### PR DESCRIPTION
site version 11 just deprecates getSentryClient. store doesn't use it anywhere, so version 11 is also compatible with store.
