### PR TITLE
Add GA4 Purchase and Shipping events

### DIFF
--- a/Store/StoreAnalyticsOrderTracker.php
+++ b/Store/StoreAnalyticsOrderTracker.php
@@ -5,7 +5,7 @@
  * Facebook pixels, Twitter pixels, and the Bing Universal Event Tracker.
  *
  * @package   Store
- * @copyright 2008-2020 silverorange
+ * @copyright 2008-2023 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  * @link      http://www.google.com/support/googleanalytics/bin/answer.py?answer=55528
  * @link      http://code.google.com/apis/analytics/docs/gaJS/gaJSApiEcommerce.html
@@ -52,7 +52,7 @@ class StoreAnalyticsOrderTracker
 	// }}}
 	// {{{ public function getGoogleAnalytics4Commands()
 
-	public function getGoogleAnalytics4Commands() : array
+	public function getGoogleAnalytics4Commands(): array
 	{
 		return [
 			$this->getGoogleAnalytics4PurchaseCommand(),
@@ -143,7 +143,7 @@ class StoreAnalyticsOrderTracker
 	// }}}
 	// {{{ protected function getGoogleAnalytics4ItemsParameter()
 
-	protected function getGoogleAnalytics4ItemsParameter() : array
+	protected function getGoogleAnalytics4ItemsParameter(): array
 	{
 		$items = [];
 		foreach($this->order->items as $item){
@@ -152,7 +152,7 @@ class StoreAnalyticsOrderTracker
 				'item_name' => $this->getProductTitle($item),
 				'item_category' => $this->getCategoryTitle($item),
 				'affiliation' => $this->affiliation,
-				'price' => $item->price
+				'price' => $item->price,
 			];
 		}
 		return $items;
@@ -161,7 +161,7 @@ class StoreAnalyticsOrderTracker
 	// }}}
 	// {{{ protected function getGoogleAnalytics4ShippingCommand()
 
-	protected function getGoogleAnalytics4ShippingCommand() : array
+	protected function getGoogleAnalytics4ShippingCommand(): array
 	{
 		return [
 			'event' => 'add_shipping_info',
@@ -176,7 +176,7 @@ class StoreAnalyticsOrderTracker
 	// }}}
 	// {{{ protected function getGoogleAnalytics4PurchaseCommand()
 
-	protected function getGoogleAnalytics4PurchaseCommand() : array
+	protected function getGoogleAnalytics4PurchaseCommand(): array
 	{
 		return [
 			'event' => 'purchase',

--- a/Store/StoreAnalyticsOrderTracker.php
+++ b/Store/StoreAnalyticsOrderTracker.php
@@ -51,7 +51,8 @@ class StoreAnalyticsOrderTracker
 
 	// }}}
 	// {{{ public function getGoogleAnalytics4Commands()
-	public function getGoogleAnalytics4Commands()
+
+	public function getGoogleAnalytics4Commands() : array
 	{
 		return [
 			$this->getGoogleAnalytics4PurchaseCommand(),
@@ -140,49 +141,34 @@ class StoreAnalyticsOrderTracker
 	}
 
 	// }}}
-	// {{{ protected function getGoogleAnalytics4ItemsCommand()
+	// {{{ protected function getGoogleAnalytics4ItemsParameter()
 
-	protected function getGoogleAnalytics4ItemsParameter()
+	protected function getGoogleAnalytics4ItemsParameter() : array
 	{
-		$item_elements = [];
+		$items = [];
 		foreach($this->order->items as $item){
-			$item_elements[] = sprintf(
-				<<<'JAVASCRIPT_OBJECT_LITERAL'
-				{
-					item_id: %s,
-					item_name: %s,
-					item_category: %s,
-					affiliation: %s,
-					price: %s
-				}
-				JAVASCRIPT_OBJECT_LITERAL
-				,
-				SwatString::quoteJavaScriptString($this->getSku($item)),
-				SwatString::quoteJavaScriptString($this->getProductTitle($item)),
-				SwatString::quoteJavaScriptString($this->getCategoryTitle($item)),
-				SwatString::quoteJavaScriptString($this->affiliation),
-				$item->price
-			);
+			$items[] = [
+				'item_id' => $this->getSku($item),
+				'item_name' => $this->getProductTitle($item),
+				'item_category' => $this->getCategoryTitle($item),
+				'affiliation' => $this->affiliation,
+				'price' => $item->price
+			];
 		}
-		return '[ '.implode(', ', $item_elements).' ]';
+		return $items;
 	}
 
 	// }}}
 	// {{{ protected function getGoogleAnalytics4ShippingCommand()
 
-	protected function getGoogleAnalytics4ShippingCommand()
+	protected function getGoogleAnalytics4ShippingCommand() : array
 	{
 		return [
 			'event' => 'add_shipping_info',
-			'parameters_javascript' => sprintf(
-				<<<'JAVASCRIPT_OBJECT_LITERAL'
-				{
-					currency: 'USD',
-					value: %s
-				}
-				JAVASCRIPT_OBJECT_LITERAL
-				,
-				$this->getShippingTotal()
+			'parameters_javascript' => json_encode([
+				'currency' => 'USD',
+				'value' => $this->getShippingTotal()
+				]
 			)
 		];
 	}
@@ -190,22 +176,15 @@ class StoreAnalyticsOrderTracker
 	// }}}
 	// {{{ protected function getGoogleAnalytics4PurchaseCommand()
 
-	protected function getGoogleAnalytics4PurchaseCommand()
+	protected function getGoogleAnalytics4PurchaseCommand() : array
 	{
 		return [
 			'event' => 'purchase',
-			'parameters_javascript' => sprintf(
-				<<<'JAVASCRIPT_OBJECT_LITERAL'
-				{
-					transaction_id: %s,
-					order_total: %s,
-					items: %s
-				}
-				JAVASCRIPT_OBJECT_LITERAL
-				,
-				SwatString::quoteJavaScriptString(strval($this->order->id)),
-				$this->getOrderTotal(),
-				$this->getGoogleAnalytics4ItemsParameter()
+			'parameters_javascript' => json_encode([
+				'transaction_id' => strval($this->order->id),
+				'order_total' => $this->getOrderTotal(),
+				'items' => $this->getGoogleAnalytics4ItemsParameter()
+				]
 			)
 		];
 	}

--- a/Store/StoreAnalyticsOrderTracker.php
+++ b/Store/StoreAnalyticsOrderTracker.php
@@ -165,11 +165,10 @@ class StoreAnalyticsOrderTracker
 	{
 		return [
 			'event' => 'add_shipping_info',
-			'parameters_javascript' => json_encode([
+			'event_params' => [
 				'currency' => 'USD',
-				'value' => $this->getShippingTotal()
-				]
-			)
+				'value'    => $this->getShippingTotal(),
+			],
 		];
 	}
 
@@ -179,13 +178,12 @@ class StoreAnalyticsOrderTracker
 	protected function getGoogleAnalytics4PurchaseCommand(): array
 	{
 		return [
-			'event' => 'purchase',
-			'parameters_javascript' => json_encode([
+			'event'        => 'purchase',
+			'event_params' => [
 				'transaction_id' => strval($this->order->id),
-				'order_total' => $this->getOrderTotal(),
-				'items' => $this->getGoogleAnalytics4ItemsParameter()
-				]
-			)
+				'order_total'    => $this->getOrderTotal(),
+				'items'          => $this->getGoogleAnalytics4ItemsParameter(),
+			]
 		];
 	}
 


### PR DESCRIPTION
GA4 includes the order items nested inside the purchase event gtag function call.
Shipping does not have city, state parameter keys (as older GA did), and shipping info goes in is a separate gtag function call.