### PR TITLE
Fix missing purchase currency key-value

### DIFF
--- a/Store/StoreAnalyticsOrderTracker.php
+++ b/Store/StoreAnalyticsOrderTracker.php
@@ -182,6 +182,7 @@ class StoreAnalyticsOrderTracker
 			'event_params' => [
 				'transaction_id' => strval($this->order->id),
 				'order_total'    => $this->getOrderTotal(),
+				'currency'       => 'USD',
 				'items'          => $this->getGoogleAnalytics4ItemsParameter(),
 			]
 		];


### PR DESCRIPTION
The currency key was moved to shipping event but it also needs to be on purchase event.