### PR TITLE
Fix purchase event key to value

### DIFF
--- a/Store/StoreAnalyticsOrderTracker.php
+++ b/Store/StoreAnalyticsOrderTracker.php
@@ -181,7 +181,7 @@ class StoreAnalyticsOrderTracker
 			'event'        => 'purchase',
 			'event_params' => [
 				'transaction_id' => strval($this->order->id),
-				'order_total'    => $this->getOrderTotal(),
+				'value'          => $this->getOrderTotal(),
 				'currency'       => 'USD',
 				'items'          => $this->getGoogleAnalytics4ItemsParameter(),
 			]


### PR DESCRIPTION
The order total key is now `value` (not order_total).