### PR TITLE
Set all smtp config settings

### DIFF
--- a/Store/StoreOrderCommentDigestMailer.php
+++ b/Store/StoreOrderCommentDigestMailer.php
@@ -81,7 +81,11 @@ class StoreOrderCommentDigestMailer extends SiteCommandLineApplication
 	{
 		$message = new SiteMultipartMailMessage($this);
 
-		$message->smtp_server  = $this->config->email->smtp_server;
+		$message->smtp_server   = $this->config->email->smtp_server;
+		$message->smtp_port     = $this->config->email->smtp_port;
+		$message->smtp_username = $this->config->email->smtp_username;
+		$message->smtp_password = $this->config->email->smtp_password;
+
 		$message->from_address = $this->config->email->website_address;
 		$message->from_name    = $this->config->site->title;
 		$message->to_address   = $this->getToAddress();

--- a/Store/StoreOrderConfirmationMailMessage.php
+++ b/Store/StoreOrderConfirmationMailMessage.php
@@ -44,7 +44,10 @@ abstract class StoreOrderConfirmationMailMessage extends
 
 		$this->order = $order;
 
-		$this->smtp_server = $this->app->config->email->smtp_server;
+		$this->smtp_server   = $this->app->config->email->smtp_server;
+		$this->smtp_port     = $this->app->config->email->smtp_port;
+		$this->smtp_username = $this->app->config->email->smtp_username;
+		$this->smtp_password = $this->app->config->email->smtp_password;
 
 		$this->from_address = $this->app->config->email->service_address;
 		$this->from_name = $this->getFromName();


### PR DESCRIPTION
This is required for the **Use Mailchimp Mandrill instead of the silverorange mailserver** [sc-55469] story.