### PR TITLE
Abstract contact link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # misc
 .DS_Store
 .env
+.idea/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/Store/pages/StoreCheckoutConfirmationPage.php
+++ b/Store/pages/StoreCheckoutConfirmationPage.php
@@ -1214,7 +1214,7 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 					'been placed. Please %scontact us%s to complete your '.
 					'order.'),
 					'<strong>', '</strong>', '<em>', '</em>',
-					'<a href="'.$this->getEditLink('about/contact').'">',
+					'<a href="'.$this->getContactSource().'">',
 					'</a>').
 				' '.$this->getErrorMessageNoFunds();
 
@@ -1260,7 +1260,7 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 						'confirmation/cart'
 					).'">',
 					'</a>',
-					'<a href="'.$this->getEditLink('about/contact').'">',
+					'<a href="'.$this->getContactSource().'">',
 					'</a>').
 				' '.$this->getErrorMessageNoFunds().
 				'</p>';
@@ -1322,7 +1322,7 @@ class StoreCheckoutConfirmationPage extends StoreCheckoutPage
 				'If you are still unable to complete your order after '.
 				'confirming your payment information, please %scontact us%s.'
 			),
-			'<a href="'.$this->getEditLink('about/contact').'">',
+			'<a href="'.$this->getContactSource().'">',
 			'</a>'
 		);
 	}

--- a/Store/pages/StoreCheckoutPage.php
+++ b/Store/pages/StoreCheckoutPage.php
@@ -172,6 +172,11 @@ abstract class StoreCheckoutPage extends SiteUiPage
 		return 'cart';
 	}
 
+	protected function getContactSource() :string
+	{
+		return 'about/contact';
+	}
+
 	// }}}
 
 	// process phase

--- a/Store/pages/StoreCheckoutPaymentFailedPage.php
+++ b/Store/pages/StoreCheckoutPaymentFailedPage.php
@@ -39,7 +39,7 @@ class StoreCheckoutPaymentFailedPage extends StoreCheckoutFinalPage
 			'process your payment. No funds were removed from your card. '.
 			'%sContact us%s to complete your order. %sYour order reference '.
 			'number is %s%s.'),
-			'<a href="about/contact">', '</a>',
+			'<a href="'.$this->getContactSource().'">', '</a>',
 			'<strong>', $order->id, '</strong>'),
 			'text/xml');
 

--- a/Store/pages/StoreExceptionPage.php
+++ b/Store/pages/StoreExceptionPage.php
@@ -23,11 +23,10 @@ class StoreExceptionPage extends SiteXhtmlExceptionPage
 	{
 		$suggestions = array();
 
-		$suggestions['contact'] = sprintf(Store::_(
+		$suggestions['contact'] = Store::_(
 			'If you followed a link from our site or elsewhere, please '.
-			'%scontact us%s and let us know where you came from so we can do '.
-			'our best to fix it.'),
-			'<a href="about/contact">', '</a>');
+			'contact us and let us know where you came from so we can do '.
+			'our best to fix it.');
 
 		$suggestions['typo'] = Store::_(
 			'If you typed in the address, please double check the spelling.');

--- a/composer.json
+++ b/composer.json
@@ -72,5 +72,11 @@
 	},
 	"autoload": {
 		"classmap": [ "Store/" ]
+	},
+	"config": {
+		"sort-packages": true,
+		"allow-plugins": {
+			"php-http/discovery": true
+		}
 	}
 }


### PR DESCRIPTION
This PR extracts out a method for setting the "contact us" link, incase you need to override it from the default of `about/contact` to some other URL.