### PR TITLE
Add required return types for Swat 7.6.0

### DIFF
--- a/Store/dataobjects/StoreOrder.php
+++ b/Store/dataobjects/StoreOrder.php
@@ -323,7 +323,7 @@ class StoreOrder extends SwatDBDataObject
 	// }}}
 	// {{{ public function duplicate()
 
-	public function duplicate()
+	public function duplicate(): static
 	{
 		$new_order = parent::duplicate();
 

--- a/Store/dataobjects/StoreOrderAddress.php
+++ b/Store/dataobjects/StoreOrderAddress.php
@@ -51,7 +51,7 @@ class StoreOrderAddress extends StoreAddress
 	// }}}
 	// {{{ public function duplicate()
 
-	public function duplicate()
+	public function duplicate(): static
 	{
 		$new_address = parent::duplicate();
 

--- a/Store/dataobjects/StoreOrderPaymentMethod.php
+++ b/Store/dataobjects/StoreOrderPaymentMethod.php
@@ -235,7 +235,7 @@ class StoreOrderPaymentMethod extends StorePaymentMethod
 	// }}}
 	// {{{ public function duplicate()
 
-	public function duplicate()
+	public function duplicate(): static
 	{
 		$new_payment_method = parent::duplicate();
 

--- a/Store/dataobjects/StorePaymentMethod.php
+++ b/Store/dataobjects/StorePaymentMethod.php
@@ -277,7 +277,7 @@ abstract class StorePaymentMethod extends SwatDBDataObject
 	// }}}
 	// {{{ public function duplicate()
 
-	public function duplicate()
+	public function duplicate(): static
 	{
 		$new_payment_method = parent::duplicate();
 


### PR DESCRIPTION
`SwatDBDataObject::duplicate()` needs to have a return type of `static` as of swat:7.6.0