### PR TITLE
Ensure classmaps are used for queries (and inline single-use vars)

### DIFF
--- a/Store/StoreAccountDeleter.php
+++ b/Store/StoreAccountDeleter.php
@@ -116,9 +116,11 @@ class StoreAccountDeleter extends SitePrivateDataDeleter
 
         $this->app->db->setLimit(self::DATA_BATCH_SIZE);
 
-        $wrapper_class = SwatDBClassMap::get(StoreAccountWrapper::class);
-
-        return SwatDB::query($this->app->db, $sql, $wrapper_class);
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreAccountWrapper::class)
+        );
     }
 
     protected function getTotal()

--- a/Store/StoreAccountPaymentMethodDeleter.php
+++ b/Store/StoreAccountPaymentMethodDeleter.php
@@ -77,10 +77,11 @@ class StoreAccountPaymentMethodDeleter extends SitePrivateDataDeleter
 
         $this->app->db->setLimit(self::DATA_BATCH_SIZE);
 
-        $wrapper_class =
-            SwatDBClassMap::get(StoreAccountPaymentMethodWrapper::class);
-
-        return SwatDB::query($this->app->db, $sql, $wrapper_class);
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreAccountPaymentMethodWrapper::class)
+        );
     }
 
     protected function getTotal()

--- a/Store/StoreLocaleApplication.php
+++ b/Store/StoreLocaleApplication.php
@@ -131,7 +131,11 @@ abstract class StoreLocaleApplication extends StoreApplication
 			(select region from Locale where id = %s)';
 
         $sql = sprintf($sql, $this->db->quote($this->locale, 'text'));
-        $regions = SwatDB::query($this->db, $sql, 'StoreRegionWrapper');
+        $regions = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreRegionWrapper::class)
+        );
         $this->region = $regions->getFirst();
 
         if ($this->region === null) {

--- a/Store/StoreOrderDeleter.php
+++ b/Store/StoreOrderDeleter.php
@@ -152,9 +152,11 @@ class StoreOrderDeleter extends SitePrivateDataDeleter
 
         $this->app->db->setLimit(self::DATA_BATCH_SIZE);
 
-        $wrapper_class = SwatDBClassMap::get(StoreOrderWrapper::class);
-
-        return SwatDB::query($this->app->db, $sql, $wrapper_class);
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreOrderWrapper::class)
+        );
     }
 
     protected function getTotal()

--- a/Store/admin/components/Account/Details.php
+++ b/Store/admin/components/Account/Details.php
@@ -145,15 +145,17 @@ class StoreAccountDetails extends SiteAccountDetails
 
     protected function getPaymentMethodsTableModel(SwatTableView $view): SwatTableStore
     {
-        $wrapper = SwatDBClassMap::get(StoreAccountPaymentMethodWrapper::class);
-
         $sql = sprintf(
             'select * from AccountPaymentMethod
 			where account = %s',
             $this->app->db->quote($this->account->id, 'integer')
         );
 
-        $payment_methods = SwatDB::query($this->app->db, $sql, $wrapper);
+        $payment_methods = SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreAccountPaymentMethodWrapper::class)
+        );
 
         $store = new SwatTableStore();
         foreach ($payment_methods as $method) {

--- a/Store/admin/components/Attribute/Index.php
+++ b/Store/admin/components/Attribute/Index.php
@@ -50,7 +50,7 @@ class StoreAttributeIndex extends AdminIndex
         $attributes = SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreAttributeWrapper'
+            SwatDBClassMap::get(StoreAttributeWrapper::class)
         );
 
         $store = new SwatTableStore();

--- a/Store/admin/components/AttributeType/Index.php
+++ b/Store/admin/components/AttributeType/Index.php
@@ -40,6 +40,10 @@ class StoreAttributeTypeIndex extends AdminIndex
     {
         $sql = 'select * from AttributeType order by shortname';
 
-        return SwatDB::query($this->app->db, $sql, StoreAttributeTypeWrapper::class);
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreAttributeTypeWrapper::class)
+        );
     }
 }

--- a/Store/admin/components/Feature/Index.php
+++ b/Store/admin/components/Feature/Index.php
@@ -129,8 +129,11 @@ class StoreFeatureIndex extends AdminIndex
             $instance_where
         );
 
-        $wrapper = SwatDBClassMap::get(StoreFeatureWrapper::class);
-        $features = SwatDB::query($this->app->db, $sql, $wrapper);
+        $features = SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreFeatureWrapper::class)
+        );
 
         $store = new SwatTableStore();
         $counts = [];

--- a/Store/admin/components/Product/Details.php
+++ b/Store/admin/components/Product/Details.php
@@ -1345,7 +1345,11 @@ class StoreProductDetails extends AdminIndex
             $this->app->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->app->db, $sql, 'StoreProductImageWrapper');
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreProductImageWrapper::class)
+        );
     }
 
     // build phase - related products

--- a/Store/admin/components/Region/Index.php
+++ b/Store/admin/components/Region/Index.php
@@ -43,6 +43,10 @@ class StoreRegionIndex extends AdminIndex
             $this->getOrderByClause($view, 'title')
         );
 
-        return SwatDB::query($this->app->db, $sql, StoreRegionWrapper::class);
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreRegionWrapper::class)
+        );
     }
 }

--- a/Store/dataobjects/StoreArticle.php
+++ b/Store/dataobjects/StoreArticle.php
@@ -64,8 +64,11 @@ class StoreArticle extends SiteArticle
             $this->db->quote($this->region->id, 'integer')
         );
 
-        $wrapper = SwatDBClassMap::get(SiteArticleWrapper::class);
-        $articles = SwatDB::query($this->db, $sql, $wrapper);
+        $articles = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(SiteArticleWrapper::class)
+        );
 
         foreach ($articles as $article) {
             $article->setRegion($this->region);
@@ -163,9 +166,11 @@ class StoreArticle extends SiteArticle
             $this->db->quote($this->region->id, 'integer')
         );
 
-        $wrapper = SwatDBClassMap::get(StoreCategoryWrapper::class);
-
-        return SwatDB::query($this->db, $sql, $wrapper);
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
+        );
     }
 
     /**
@@ -198,9 +203,11 @@ class StoreArticle extends SiteArticle
             $this->db->quote($this->region->id, 'integer')
         );
 
-        $wrapper = SwatDBClassMap::get(StoreProductWrapper::class);
-
-        return SwatDB::query($this->db, $sql, $wrapper);
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreProductWrapper::class)
+        );
     }
 
     /**
@@ -228,8 +235,11 @@ class StoreArticle extends SiteArticle
             $this->db->quote($this->region->id, 'integer')
         );
 
-        $wrapper = SwatDBClassMap::get(SiteArticleWrapper::class);
-        $articles = SwatDB::query($this->db, $sql, $wrapper);
+        $articles = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(SiteArticleWrapper::class)
+        );
 
         foreach ($articles as $article) {
             $article->setRegion($this->region);

--- a/Store/dataobjects/StoreCatalog.php
+++ b/Store/dataobjects/StoreCatalog.php
@@ -75,8 +75,11 @@ class StoreCatalog extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        $wrapper_class = SwatDBClassMap::get(StoreCatalogWrapper::class);
-        $clones = SwatDB::query($this->db, $sql, $wrapper_class);
+        $clones = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreCatalogWrapper::class)
+        );
 
         return $clones->getFirst();
     }

--- a/Store/dataobjects/StoreCategory.php
+++ b/Store/dataobjects/StoreCategory.php
@@ -403,8 +403,11 @@ class StoreCategory extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        $wrapper_class = SwatDBClassMap::get(StoreCategoryWrapper::class);
-        $sub_categories = SwatDB::query($this->db, $sql, $wrapper_class);
+        $sub_categories = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
+        );
         $sub_categories->setRegion($region);
 
         return $sub_categories;
@@ -450,8 +453,11 @@ class StoreCategory extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        $wrapper_class = SwatDBClassMap::get(StoreProductWrapper::class);
-        $products = SwatDB::query($this->db, $sql, $wrapper_class);
+        $products = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreProductWrapper::class)
+        );
         $products->setRegion($region);
 
         return $products;
@@ -733,8 +739,11 @@ class StoreCategory extends SwatDBDataObject
             $this->db->quote($this->region->id, 'integer')
         );
 
-        $wrapper = SwatDBClassMap::get(StoreCategoryWrapper::class);
-        $categories = SwatDB::query($this->db, $sql, $wrapper);
+        $categories = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
+        );
 
         foreach ($categories as $category) {
             $category->setRegion($this->region);

--- a/Store/dataobjects/StoreFeatureWrapper.php
+++ b/Store/dataobjects/StoreFeatureWrapper.php
@@ -58,7 +58,7 @@ class StoreFeatureWrapper extends SwatDBRecordsetWrapper
             $all_features = SwatDB::query(
                 $app->db,
                 $sql,
-                'StoreFeatureWrapper'
+                SwatDBClassMap::get(StoreFeatureWrapper::class)
             );
 
             $expiry = 0;

--- a/Store/dataobjects/StoreItem.php
+++ b/Store/dataobjects/StoreItem.php
@@ -866,9 +866,11 @@ class StoreItem extends SwatDBDataObject
         $sql = 'select * from ItemRegionBinding where item = %s';
         $sql = sprintf($sql, $this->db->quote($this->id, 'integer'));
 
-        $wrapper = SwatDBClassMap::get(StoreItemRegionBindingWrapper::class);
-
-        return SwatDB::query($this->db, $sql, $wrapper);
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreItemRegionBindingWrapper::class)
+        );
     }
 
     protected function loadItemAliases()

--- a/Store/dataobjects/StoreItemGroup.php
+++ b/Store/dataobjects/StoreItemGroup.php
@@ -118,8 +118,12 @@ class StoreItemGroup extends SwatDBDataObject
             );
         }
 
-        $wrapper = SwatDBClassMap::get(StoreItemWrapper::class);
-        $rs = SwatDB::query($this->db, $sql, $wrapper);
+        $rs = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreItemWrapper::class)
+        );
+
         if (count($rs) > 0) {
             $cheapest_item = $rs->getFirst();
             $cheapest_item->setRegion($this->region);

--- a/Store/dataobjects/StoreProduct.php
+++ b/Store/dataobjects/StoreProduct.php
@@ -743,8 +743,11 @@ class StoreProduct extends SwatDBDataObject
             );
         }
 
-        $wrapper = SwatDBClassMap::get(StoreItemWrapper::class);
-        $cheapest_item = SwatDB::query($this->db, $sql, $wrapper)->getFirst();
+        $cheapest_item = SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreItemWrapper::class)
+        )->getFirst();
 
         if ($cheapest_item != null) {
             $cheapest_item->setRegion($this->region);
@@ -787,10 +790,11 @@ class StoreProduct extends SwatDBDataObject
             );
         }
 
-        $wrapper = SwatDBClassMap::get(StoreProductImageWrapper::class);
-        $rs = SwatDB::query($this->db, $sql, $wrapper);
-
-        return $rs->getFirst();
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreProductImageWrapper::class)
+        )->getFirst();
     }
 
     /**

--- a/Store/dataobjects/StoreProductWrapper.php
+++ b/Store/dataobjects/StoreProductWrapper.php
@@ -67,7 +67,11 @@ class StoreProductWrapper extends SwatDBRecordsetWrapper
                 $attribute_ids
             );
 
-            $attributes = SwatDB::query($this->db, $sql, $wrapper_class);
+            $attributes = SwatDB::query(
+                $this->db,
+                $sql,
+                SwatDBClassMap::get(StoreAttributeWrapper::class)
+            );
 
             foreach ($bindings as $binding) {
                 $product = $this->getByIndex($binding->product);

--- a/Store/dataobjects/StoreQuantityDiscount.php
+++ b/Store/dataobjects/StoreQuantityDiscount.php
@@ -194,11 +194,11 @@ class StoreQuantityDiscount extends SwatDBDataObject
 
         $sql = sprintf($sql, $this->db->quote($this->id, 'integer'));
 
-        $wrapper = SwatDBClassMap::get(
-            'StoreQuantityDiscountRegionBindingWrapper'
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreQuantityDiscountRegionBindingWrapper::class)
         );
-
-        return SwatDB::query($this->db, $sql, $wrapper);
     }
 
     // saver methods

--- a/Store/dataobjects/StoreRegion.php
+++ b/Store/dataobjects/StoreRegion.php
@@ -56,7 +56,11 @@ class StoreRegion extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'StoreLocaleWrapper');
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreLocaleWrapper::class)
+        );
     }
 
     /**
@@ -125,7 +129,11 @@ class StoreRegion extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'StoreCountryWrapper');
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreCountryWrapper::class)
+        );
     }
 
     /**
@@ -146,7 +154,11 @@ class StoreRegion extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'StoreCountryWrapper');
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreCountryWrapper::class)
+        );
     }
 
     /**
@@ -167,7 +179,11 @@ class StoreRegion extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'StoreProvStateWrapper');
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreProvStateWrapper::class)
+        );
     }
 
     /**
@@ -188,6 +204,10 @@ class StoreRegion extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'StoreProvStateWrapper');
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get(StoreProvStateWrapper::class)
+        );
     }
 }

--- a/Store/dataobjects/StoreRegionWrapper.php
+++ b/Store/dataobjects/StoreRegionWrapper.php
@@ -14,7 +14,11 @@ class StoreRegionWrapper extends SwatDBRecordsetWrapper
 
         $sql = sprintf($sql, $id_set);
 
-        return SwatDB::query($db, $sql, 'RegionWrapper');
+        return SwatDB::query(
+            $db,
+            $sql,
+            SwatDBClassMap::get(StoreRegionWrapper::class)
+        );
     }
 
     protected function init()

--- a/Store/pages/StoreArticleNotVisiblePage.php
+++ b/Store/pages/StoreArticleNotVisiblePage.php
@@ -49,7 +49,7 @@ class StoreArticleNotVisiblePage extends StoreNotVisiblePage
         return SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreRegionWrapper'
+            SwatDBClassMap::get(StoreRegionWrapper::class)
         );
     }
 

--- a/Store/pages/StoreCategoryNotVisiblePage.php
+++ b/Store/pages/StoreCategoryNotVisiblePage.php
@@ -24,7 +24,7 @@ class StoreCategoryNotVisiblePage extends StoreNotVisiblePage
         $categories = SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreCategoryWrapper'
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
         );
 
         $category = $categories->getFirst();
@@ -57,7 +57,7 @@ class StoreCategoryNotVisiblePage extends StoreNotVisiblePage
         return SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreRegionWrapper'
+            SwatDBClassMap::get(StoreRegionWrapper::class)
         );
     }
 

--- a/Store/pages/StoreCategoryPage.php
+++ b/Store/pages/StoreCategoryPage.php
@@ -198,8 +198,11 @@ class StoreCategoryPage extends StorePage
             $this->app->db->quote($this->app->getRegion()->id, 'integer')
         );
 
-        $wrapper_class = SwatDBClassMap::get(StoreCategoryWrapper::class);
-        $sub_categories = SwatDB::query($this->app->db, $sql, $wrapper_class);
+        $sub_categories = SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
+        );
         $sub_categories->setRegion($this->app->getRegion());
 
         if (count($sub_categories) == 0) {
@@ -207,12 +210,11 @@ class StoreCategoryPage extends StorePage
         }
 
         $sql = 'select * from Image where id in (%s)';
-        $wrapper_class = SwatDBClassMap::get(StoreCategoryImageWrapper::class);
         $sub_categories->loadAllSubDataObjects(
             'image',
             $this->app->db,
             $sql,
-            $wrapper_class
+            SwatDBClassMap::get(StoreCategoryImageWrapper::class)
         );
 
         return $sub_categories;

--- a/Store/pages/StoreCheckoutShippingTypePage.php
+++ b/Store/pages/StoreCheckoutShippingTypePage.php
@@ -102,9 +102,11 @@ class StoreCheckoutShippingTypePage extends StoreCheckoutEditPage
             $this->app->db->quote($this->app->getRegion()->id, 'integer')
         );
 
-        $wrapper = SwatDBClassMap::get(StoreShippingTypeWrapper::class);
-
-        return SwatDB::query($this->app->db, $sql, $wrapper);
+        return SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreShippingTypeWrapper::class)
+        );
     }
 
     // finalize phase

--- a/Store/pages/StorePage.php
+++ b/Store/pages/StorePage.php
@@ -91,7 +91,7 @@ abstract class StorePage extends SitePathPage
         $categories = SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreCategoryWrapper'
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
         );
 
         $category = $categories->getFirst();

--- a/Store/pages/StoreProductNotVisiblePage.php
+++ b/Store/pages/StoreProductNotVisiblePage.php
@@ -24,7 +24,7 @@ class StoreProductNotVisiblePage extends StoreNotVisiblePage
         $categories = SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreProductWrapper'
+            SwatDBClassMap::get(StoreProductWrapper::class)
         );
 
         $product = $categories->getFirst();
@@ -56,7 +56,7 @@ class StoreProductNotVisiblePage extends StoreNotVisiblePage
         return SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreRegionWrapper'
+            SwatDBClassMap::get(StoreRegionWrapper::class)
         );
     }
 

--- a/Store/pages/StoreSearchPage.php
+++ b/Store/pages/StoreSearchPage.php
@@ -63,7 +63,7 @@ class StoreSearchPage extends StoreSearchResultsPage
         return SwatDB::query(
             $this->app->db,
             $sql,
-            'StoreCategoryWrapper'
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
         );
     }
 

--- a/Store/pages/StoreSearchPanelServer.php
+++ b/Store/pages/StoreSearchPanelServer.php
@@ -123,7 +123,7 @@ class StoreSearchPanelServer extends SiteXMLRPCServer
             $category = SwatDB::query(
                 $this->app->db,
                 $sql,
-                'StoreCategoryWrapper'
+                SwatDBClassMap::get(StoreCategoryWrapper::class)
             )->getFirst();
         }
 

--- a/Store/pages/StoreSearchResultsPage.php
+++ b/Store/pages/StoreSearchResultsPage.php
@@ -290,7 +290,7 @@ class StoreSearchResultsPage extends SiteSearchResultsPage
             $category = SwatDB::query(
                 $this->app->db,
                 $sql,
-                'StoreCategoryWrapper'
+                SwatDBClassMap::get(StoreCategoryWrapper::class)
             )->getFirst();
         }
 

--- a/Store/pages/StoreXmlSiteMapPage.php
+++ b/Store/pages/StoreXmlSiteMapPage.php
@@ -53,15 +53,17 @@ class StoreXmlSiteMapPage extends SiteXmlSiteMapPage
 
     protected function queryCategories()
     {
-        $wrapper = SwatDBClassMap::get(StoreCategoryWrapper::class);
-
         $sql = 'select id, shortname
 			from Category
 			where parent is null
 				and id in (select category from VisibleCategoryView)
 			order by displayorder, title';
 
-        $categories = SwatDB::query($this->app->db, $sql, $wrapper);
+        $categories = SwatDB::query(
+            $this->app->db,
+            $sql,
+            SwatDBClassMap::get(StoreCategoryWrapper::class)
+        );
         $categories->setRegion($this->app->getRegion());
 
         return $categories;


### PR DESCRIPTION
Ensures that, for all `SwatDB::query()` calls that pass in a wrapping class, the wrapping class is resolved via `SwatDBClassMap::get()`.

Also, removes single-use variables for the wrapper and inlines them.  e.g.:

```php
$wrapper = SwatDBClassMap::get(Foo::class);
return SwatDB::query(
    $db,
    $sql,
    $wrapper
);
```

becomes:

```php
return SwatDB::query(
    $db,
    $sql,
    SwatDBClassMap::get(Foo::class);
);
```
